### PR TITLE
Add user and process level GPU logging modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,24 @@
 <img src="google_sheet.png" alt="Google Sheet Example" width="60%">
 
 Simple GPU-usage logger based on Google Cloud API
-* Google Cloud Service instructions from ChatGPT (written in 25.08, **DO NOT UPLOAD YOUR CREDIENTIAL FILES ONLINE!**)  
+* Google Cloud Service instructions from ChatGPT (written in 25.08, **DO NOT UPLOAD YOUR CREDIENTIAL FILES ONLINE!**)
   <img src="chatgpt_guide.png"  width="60%">
 * Google Sheet example color & number formattings example [link](https://docs.google.com/spreadsheets/d/1CgUvc--pjhSz-DaDB7aL1pu_jVzZ7MLml-cEmmmwe8Q/edit?usp=sharing)
-* Required python packages:  
+* Required python packages:
   ```pip install pynvml psutil gspread google-auth pytz```
 * Without using python virtual enviornment we encountered an error related to external package restrictions. We used the following command to resolve the problem:  
   ```python3 -m pip config set global.break-system-packages true``` 
 * We used a tmux session to run the script (run.sh) in the background.
+
+#### Internal vs. External logging
+
+Set `SERVER_TYPE` to `internal` to aggregate usage per user or to
+`external` to log every GPU-bound process. The script writes to separate
+worksheets:
+
+| Variable | Description |
+| --- | --- |
+| `SHEET_TAB_USERS` | Worksheet for `internal` servers (default `GPU_USERS`) |
+| `SHEET_TAB_PROCS` | Worksheet for `external` servers (default `GPU_PROCS`) |
+
+See `run.sh` for an example of the required environment variables.

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,10 @@ set -euo pipefail
 
 export ROW=2
 export SERVER_NAME="SERVER_NAME"
-export SHEET_ID="<sheet_id>"                                 # https://docs.google.com/spreadsheets/d/<sheet_id>/edit ...
+export SERVER_TYPE="internal"              # or "external"
+export SHEET_ID="<sheet_id>"                # https://docs.google.com/spreadsheets/d/<sheet_id>/edit ...
+export SHEET_TAB_USERS="GPU_USERS"          # worksheet for internal servers
+export SHEET_TAB_PROCS="GPU_PROCS"          # worksheet for external servers
 export GOOGLE_APPLICATION_CREDENTIALS="your_key_path.json"
 
 # update sheet every 60 seconds

--- a/update_gsheet.py
+++ b/update_gsheet.py
@@ -1,70 +1,121 @@
-import os, time, datetime, pytz
-import pynvml as nv
+"""Log GPU usage to Google Sheets.
+
+This script supports two modes depending on the ``SERVER_TYPE``
+environment variable:
+
+``internal``
+    Aggregates GPU memory usage per user on each GPU.
+
+``external``
+    Records a row for every GPU-bound process including the command
+    line, user name and PID.
+
+Rows are written to separate Google Sheet tabs so that internal and
+external servers can be managed independently.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+from collections import defaultdict
+
 import gspread
+import psutil
+import pynvml as nv
+import pytz
 from google.oauth2.service_account import Credentials
 
-# --- CONFIG ---
-TZ = pytz.timezone("Asia/Seoul")
-if True:
-    SHEET_ID = os.environ.get("SHEET_ID")              # e.g., 1AbC...XYZ
-    SHEET_TAB = os.environ.get("SHEET_TAB", "GPU")     # worksheet/tab name
-    SA_JSON   = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")  # path to service account JSON
-    # --- AUTH ---
-    scopes = ["https://www.googleapis.com/auth/spreadsheets"]
-    creds = Credentials.from_service_account_file(SA_JSON, scopes=scopes)
-    gc = gspread.authorize(creds)
-    sh = gc.open_by_key(SHEET_ID)
-    try:
-        ws = sh.worksheet(SHEET_TAB)
-    except gspread.exceptions.WorksheetNotFound:
-        print('create a tab named GPU')
-        assert False
-        # ws = sh.add_worksheet(title=SHEET_TAB, rows=1, cols=12)
-        # ws.append_row(["timestamp","host","gpu_index","name","util_percent","mem_used_GB","mem_total_GB","temp_C"])
 
-# --- GPU METRICS ---
+# ---------------------------------------------------------------------------
+# Configuration & Google Sheet access
+# ---------------------------------------------------------------------------
+
+TZ = pytz.timezone("Asia/Seoul")
+
+SERVER_TYPE = os.environ.get("SERVER_TYPE", "internal").lower()
+if SERVER_TYPE not in {"internal", "external"}:
+    raise ValueError("SERVER_TYPE must be 'internal' or 'external'")
+
+SHEET_ID = os.environ.get("SHEET_ID")
+SA_JSON = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+TAB_USERS = os.environ.get("SHEET_TAB_USERS", "GPU_USERS")
+TAB_PROCS = os.environ.get("SHEET_TAB_PROCS", "GPU_PROCS")
+
+scopes = ["https://www.googleapis.com/auth/spreadsheets"]
+creds = Credentials.from_service_account_file(SA_JSON, scopes=scopes)
+gc = gspread.authorize(creds)
+sh = gc.open_by_key(SHEET_ID)
+tab_name = TAB_USERS if SERVER_TYPE == "internal" else TAB_PROCS
+try:
+    ws = sh.worksheet(tab_name)
+except gspread.exceptions.WorksheetNotFound as exc:  # pragma: no cover - requires remote sheet
+    raise RuntimeError(f"Worksheet {tab_name} not found") from exc
+
+
+# ---------------------------------------------------------------------------
+# GPU information gathering
+# ---------------------------------------------------------------------------
+
 nv.nvmlInit()
 host = os.environ.get("SERVER_NAME", os.uname().nodename)
-# now = datetime.datetime.now(TZ).strftime("%Y-%m-%d %H:%M:%S%z")
 now = datetime.datetime.now(TZ).strftime("%m-%d / %H:%M:%S")
 
-rows = []
+rows: list[list[object]] = []
+
 for i in range(nv.nvmlDeviceGetCount()):
-    h = nv.nvmlDeviceGetHandleByIndex(i)
-    name = nv.nvmlDeviceGetName(h)
-    util = nv.nvmlDeviceGetUtilizationRates(h).gpu
-    gpu_mem  = nv.nvmlDeviceGetMemoryInfo(h)
-    temp = nv.nvmlDeviceGetTemperature(h, nv.NVML_TEMPERATURE_GPU)
+    handle = nv.nvmlDeviceGetHandleByIndex(i)
+    util = nv.nvmlDeviceGetUtilizationRates(handle).gpu
+    gpu_mem = nv.nvmlDeviceGetMemoryInfo(handle)
+    total_gb = round(gpu_mem.total / (1024 ** 3), 3)
 
     try:
-        power_w = nv.nvmlDeviceGetPowerUsage(h) / 1000.0
+        proc_infos = nv.nvmlDeviceGetComputeRunningProcesses(handle)
     except nv.NVMLError_NotSupported:
-        power_w = "N/A"
+        proc_infos = []
 
-    # Power cap (what’s actually enforced right now)
-    try:
-        power_cap_w = nv.nvmlDeviceGetEnforcedPowerLimit(h) / 1000.0
-    except nv.NVMLError_NotSupported:
-        power_cap_w = "N/A"
-
-    # head
-    # Update	Server	IDX	Util (%)	VRAM used	VRAM total	Temp	P (Usage)	P (Limit)	Type
-    
-    rows.append([
-        now, host, i, util,
-        round(gpu_mem.used/(1.0 * (1024 ** 3)),3), round(gpu_mem.total/(1.0 * (1024 ** 3)),3),
-        temp, power_w, power_cap_w, name
-    ])
-
-# Batch append (1 API call even for many GPUs)
-start_row = int(os.environ.get("ROW"))
-end_row = start_row + len(rows) - 1
-range_str = f"A{start_row}:J{end_row}"  # adjust H to your last column
-
-
-if rows:
-    # ws.append_rows(rows, value_input_option="USER_ENTERED")
-    ws.update(range_name=range_str, values=rows, value_input_option="USER_ENTERED")
+    if SERVER_TYPE == "internal":
+        usage_by_user: dict[str, float] = defaultdict(float)
+        for p in proc_infos:
+            mem_gb = round(p.usedGpuMemory / (1024 ** 3), 3)
+            try:
+                user = psutil.Process(p.pid).username()
+            except psutil.Error:
+                user = "unknown"
+            usage_by_user[user] += mem_gb
+        if not usage_by_user:
+            usage_by_user["IDLE"] = 0.0
+        for user, mem in usage_by_user.items():
+            rows.append([now, host, user, i, mem, total_gb, util])
+    else:  # external
+        if not proc_infos:
+            rows.append([now, host, 0, "IDLE", "-", i, 0.0, total_gb, util])
+        for p in proc_infos:
+            mem_gb = round(p.usedGpuMemory / (1024 ** 3), 3)
+            try:
+                proc = psutil.Process(p.pid)
+                user = proc.username()
+                cmd = " ".join(proc.cmdline())[:40]
+            except psutil.Error:
+                user = "unknown"
+                cmd = "unknown"
+            rows.append([now, host, p.pid, cmd, user, i, mem_gb, total_gb, util])
 
 nv.nvmlShutdown()
+
+
+# ---------------------------------------------------------------------------
+# Sheet update
+# ---------------------------------------------------------------------------
+
+start_row = int(os.environ.get("ROW", "2"))
+end_row = start_row + len(rows) - 1
+
+if SERVER_TYPE == "internal":
+    range_str = f"A{start_row}:G{end_row}"
+else:
+    range_str = f"A{start_row}:I{end_row}"
+
+if rows:  # pragma: no branch - simple batch update
+    ws.update(range_name=range_str, values=rows, value_input_option="USER_ENTERED")
 


### PR DESCRIPTION
## Summary
- Support internal (user-based) and external (process-based) GPU logging modes
- Expose environment variables for sheet tabs and server type
- Document new workflow and update run script example

## Testing
- `python -m py_compile update_gsheet.py`
- `bash -n run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68abe6531910832f89b1caf31e668408